### PR TITLE
Fixed #40

### DIFF
--- a/src/main/java/com/finallion/graveyard/TheGraveyard.java
+++ b/src/main/java/com/finallion/graveyard/TheGraveyard.java
@@ -1,6 +1,15 @@
 package com.finallion.graveyard;
 
 import com.finallion.graveyard.config.GraveyardConfig;
+import com.finallion.graveyard.entities.AcolyteEntity;
+import com.finallion.graveyard.entities.CorruptedIllager;
+import com.finallion.graveyard.entities.CorruptedPillager;
+import com.finallion.graveyard.entities.GhoulEntity;
+import com.finallion.graveyard.entities.NightmareEntity;
+import com.finallion.graveyard.entities.ReaperEntity;
+import com.finallion.graveyard.entities.RevenantEntity;
+import com.finallion.graveyard.entities.SkeletonCreeper;
+import com.finallion.graveyard.entities.WraithEntity;
 import com.finallion.graveyard.init.*;
 
 
@@ -13,6 +22,7 @@ import net.fabricmc.fabric.api.client.itemgroup.FabricItemGroupBuilder;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.item.ItemStack;
@@ -55,6 +65,15 @@ public class TheGraveyard implements ModInitializer {
             BiomeModification.init();
         }
 
+        FabricDefaultAttributeRegistry.register(TGEntities.REAPER, ReaperEntity.createReaperAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.ACOLYTE, CorruptedIllager.createCorruptedIllegerAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.CORRUPTED_VINDICATOR, CorruptedIllager.createCorruptedIllegerAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.CORRUPTED_PILLAGER, CorruptedPillager.createCorruptedPillagerAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.SKELETON_CREEPER, SkeletonCreeper.createSkeletonCreeperAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.GHOUL, GhoulEntity.createGhoulAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.REVENANT, RevenantEntity.createRevenantAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.WRAITH, WraithEntity.createWraithAttributes());
+        FabricDefaultAttributeRegistry.register(TGEntities.NIGHTMARE, NightmareEntity.createNightmareAttributes());
     }
 
     public static ItemGroup GROUP = FabricItemGroupBuilder.create(

--- a/src/main/java/com/finallion/graveyard/entities/AcolyteEntity.java
+++ b/src/main/java/com/finallion/graveyard/entities/AcolyteEntity.java
@@ -8,6 +8,7 @@ import net.minecraft.entity.ai.NavigationConditions;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.ai.pathing.MobNavigation;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
@@ -34,8 +35,6 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 public class AcolyteEntity extends CorruptedIllager {
-    private AttributeContainer attributeContainer;
-
     public AcolyteEntity(EntityType<? extends CorruptedIllager> entityType, World world) {
         super(entityType, world, "acolyte");
     }
@@ -44,15 +43,7 @@ public class AcolyteEntity extends CorruptedIllager {
     protected void initEquipment(LocalDifficulty difficulty) {
         this.equipStack(EquipmentSlot.MAINHAND, new ItemStack(Registry.ITEM.get(new Identifier(TheGraveyard.MOD_ID, "bone_dagger"))));
     }
-
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null)
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.3499999940395355D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 12.0D).add(EntityAttributes.GENERIC_MAX_HEALTH, 24.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 5.0D).build());
-        return attributeContainer;
-    }
-
+    
     @Override
     public void playAmbientSound() {
         this.playSound(SoundEvents.ENTITY_VINDICATOR_AMBIENT, 1.0F, 1.0F);

--- a/src/main/java/com/finallion/graveyard/entities/CorruptedIllager.java
+++ b/src/main/java/com/finallion/graveyard/entities/CorruptedIllager.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.ai.NavigationConditions;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.ai.pathing.MobNavigation;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.mob.HostileEntity;
@@ -24,8 +25,6 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class CorruptedIllager extends HordeGraveyardEntity {
-    private AttributeContainer attributeContainer;
-
     public CorruptedIllager(EntityType<? extends CorruptedIllager> entityType, World world, String name) {
         super(entityType, world, name);
     }
@@ -68,12 +67,8 @@ public abstract class CorruptedIllager extends HordeGraveyardEntity {
         return false;
     }
 
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null)
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.3499999940395355D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 12.0D).add(EntityAttributes.GENERIC_MAX_HEALTH, 24.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 5.0D).build());
-        return attributeContainer;
+    public static DefaultAttributeContainer.Builder createCorruptedIllegerAttributes() {
+    	return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.3499999940395355D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 12.0D).add(EntityAttributes.GENERIC_MAX_HEALTH, 24.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 5.0D);
     }
 
     public State getState() {

--- a/src/main/java/com/finallion/graveyard/entities/CorruptedPillager.java
+++ b/src/main/java/com/finallion/graveyard/entities/CorruptedPillager.java
@@ -4,6 +4,7 @@ import com.finallion.graveyard.TheGraveyard;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
@@ -14,19 +15,14 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.world.World;
 
 public class CorruptedPillager extends CorruptedIllager {
-    private AttributeContainer attributeContainer;
-
     public CorruptedPillager(EntityType<? extends CorruptedIllager> entityType, World world) {
         super(entityType, world, "corrupted_pillager");
     }
 
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null)
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.3499999940395355D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 12.0D).add(EntityAttributes.GENERIC_MAX_HEALTH, 24.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 3.0D).build());
-        return attributeContainer;
+    public static DefaultAttributeContainer.Builder createCorruptedPillagerAttributes() {
+    	return CorruptedIllager.createCorruptedIllegerAttributes().add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 3.0D);
     }
-
+    
     @Override
     public CorruptedIllager.State getState() {
         if (this.isAttacking()) {

--- a/src/main/java/com/finallion/graveyard/entities/CorruptedVindicator.java
+++ b/src/main/java/com/finallion/graveyard/entities/CorruptedVindicator.java
@@ -4,6 +4,7 @@ import com.finallion.graveyard.TheGraveyard;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
@@ -14,18 +15,8 @@ import net.minecraft.sound.SoundEvents;
 import net.minecraft.world.World;
 
 public class CorruptedVindicator extends CorruptedIllager {
-    private AttributeContainer attributeContainer;
-
     public CorruptedVindicator(EntityType<? extends CorruptedIllager> entityType, World world) {
         super(entityType, world, "corrupted_vindicator");
-    }
-
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null)
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.3499999940395355D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 12.0D).add(EntityAttributes.GENERIC_MAX_HEALTH, 24.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 5.0D).build());
-        return attributeContainer;
     }
 
     @Override

--- a/src/main/java/com/finallion/graveyard/entities/GhoulEntity.java
+++ b/src/main/java/com/finallion/graveyard/entities/GhoulEntity.java
@@ -4,6 +4,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -35,7 +36,6 @@ import software.bernie.geckolib3.core.manager.AnimationFactory;
 import java.util.UUID;
 
 public class GhoulEntity extends AngerableGraveyardEntity implements IAnimatable {
-    private AttributeContainer attributeContainer;
     protected static final TrackedData<Byte> ANIMATION_MOVE_STATE = DataTracker.registerData(GhoulEntity.class, TrackedDataHandlerRegistry.BYTE);
     private final AnimationBuilder DEATH_ANIMATION = new AnimationBuilder().addAnimation("death", false);
     private final AnimationBuilder IDLE_ANIMATION = new AnimationBuilder().addAnimation("idle", true);
@@ -99,20 +99,15 @@ public class GhoulEntity extends AngerableGraveyardEntity implements IAnimatable
         this.targetSelector.add(3, new ActiveTargetGoal<>(this, MerchantEntity.class, false));
         this.targetSelector.add(3, new ActiveTargetGoal<>(this, IronGolemEntity.class, true));
     }
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
-                    .add(EntityAttributes.GENERIC_FOLLOW_RANGE, 30.0D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.155D)
-                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 4.0D)
-                    .add(EntityAttributes.GENERIC_ARMOR, 3.0D)
-                    .add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 0.5D).build());
-        }
-        return attributeContainer;
+    
+    public static DefaultAttributeContainer.Builder createGhoulAttributes() {
+    	return HostileEntity.createHostileAttributes()
+                .add(EntityAttributes.GENERIC_FOLLOW_RANGE, 30.0D)
+                .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.155D)
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 4.0D)
+                .add(EntityAttributes.GENERIC_ARMOR, 3.0D)
+                .add(EntityAttributes.GENERIC_KNOCKBACK_RESISTANCE, 0.5D);
     }
-
 
     public EntityGroup getGroup() {
         return EntityGroup.UNDEAD;

--- a/src/main/java/com/finallion/graveyard/entities/NightmareEntity.java
+++ b/src/main/java/com/finallion/graveyard/entities/NightmareEntity.java
@@ -10,6 +10,7 @@ import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.control.MoveControl;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -54,7 +55,6 @@ import java.util.UUID;
 import java.util.function.Predicate;
 
 public class NightmareEntity extends HostileGraveyardEntity implements IAnimatable, Angerable {
-    private AttributeContainer attributeContainer;
     private AnimationFactory factory = new AnimationFactory(this);
     private final AnimationBuilder DEATH_ANIMATION = new AnimationBuilder().addAnimation("death", false);
     private final AnimationBuilder IDLE_ANIMATION = new AnimationBuilder().addAnimation("idle", true);
@@ -191,14 +191,11 @@ public class NightmareEntity extends HostileGraveyardEntity implements IAnimatab
         return PlayState.CONTINUE;
 
     }
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 50.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 10.0D).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.19D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 64.0D).build());
-        }
-        return attributeContainer;
+    
+    public static DefaultAttributeContainer.Builder createNightmareAttributes() {
+    	return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 50.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 10.0D).add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.19D).add(EntityAttributes.GENERIC_FOLLOW_RANGE, 64.0D);
     }
-
+    
     @Override
     protected void updatePostDeath() {
         ++this.deathTime;

--- a/src/main/java/com/finallion/graveyard/entities/ReaperEntity.java
+++ b/src/main/java/com/finallion/graveyard/entities/ReaperEntity.java
@@ -6,6 +6,7 @@ import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.ai.control.MoveControl;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.data.DataTracker;
@@ -39,7 +40,6 @@ import software.bernie.geckolib3.core.manager.AnimationFactory;
 import java.util.EnumSet;
 
 public class ReaperEntity extends HostileGraveyardEntity implements IAnimatable {
-    private AttributeContainer attributeContainer;
     private AnimationFactory factory = new AnimationFactory(this);
     private final AnimationBuilder DEATH_ANIMATION = new AnimationBuilder().addAnimation("death", false);
     private final AnimationBuilder IDLE_ANIMATION = new AnimationBuilder().addAnimation("idle", true);
@@ -182,14 +182,10 @@ public class ReaperEntity extends HostileGraveyardEntity implements IAnimatable 
     }
 
 
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_MAX_HEALTH, 20.0D).add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 4.0D).build());
-        }
-        return attributeContainer;
+    public static DefaultAttributeContainer.Builder createReaperAttributes() {
+    	return HostileEntity.createHostileAttributes().add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 4.0D);
     }
-
+    
     public byte getAnimation() {
         return dataTracker.get(ANIMATION);
     }

--- a/src/main/java/com/finallion/graveyard/entities/RevenantEntity.java
+++ b/src/main/java/com/finallion/graveyard/entities/RevenantEntity.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.goal.*;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.data.DataTracker;
@@ -38,7 +39,6 @@ import software.bernie.geckolib3.core.manager.AnimationData;
 import software.bernie.geckolib3.core.manager.AnimationFactory;
 
 public class RevenantEntity extends AngerableGraveyardEntity implements IAnimatable {
-    private AttributeContainer attributeContainer;
     private AnimationFactory factory = new AnimationFactory(this);
     private final AnimationBuilder DEATH_ANIMATION = new AnimationBuilder().addAnimation("death", false);
     private final AnimationBuilder IDLE_ANIMATION = new AnimationBuilder().addAnimation("idle", true);
@@ -74,20 +74,14 @@ public class RevenantEntity extends AngerableGraveyardEntity implements IAnimata
     public double squaredAttackRange(LivingEntity target) {
         return ATTACK_RANGE;
     }
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
-                    .add(EntityAttributes.GENERIC_MAX_HEALTH, 20.0D)
-                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 3.5D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.155D)
-                    .add(EntityAttributes.GENERIC_FOLLOW_RANGE, 35.0D)
-                    .build());
-        }
-        return attributeContainer;
+    
+    public static DefaultAttributeContainer.Builder createRevenantAttributes() {
+    	return HostileEntity.createHostileAttributes()
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 3.5D)
+                .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.155D)
+                .add(EntityAttributes.GENERIC_FOLLOW_RANGE, 35.0D);
     }
-
+    
     @Override
     public void tickMovement() {
         timeSinceLastAttack--;

--- a/src/main/java/com/finallion/graveyard/entities/SkeletonCreeper.java
+++ b/src/main/java/com/finallion/graveyard/entities/SkeletonCreeper.java
@@ -5,6 +5,7 @@ import com.finallion.graveyard.init.TGBlocks;
 import net.minecraft.entity.*;
 import net.minecraft.entity.ai.TargetPredicate;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.effect.StatusEffectInstance;
@@ -25,7 +26,6 @@ import java.util.Iterator;
 import java.util.Random;
 
 public class SkeletonCreeper extends CreeperEntity {
-    private AttributeContainer attributeContainer;
     private static final TargetPredicate CLOSE_PLAYER_PREDICATE;
     private PlayerEntity closestPlayer;
     private final double explosionRadius = 3.5D;
@@ -33,15 +33,11 @@ public class SkeletonCreeper extends CreeperEntity {
     public SkeletonCreeper(EntityType<? extends CreeperEntity> entityType, World world) {
         super(entityType, world);
     }
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if(attributeContainer == null)
-            attributeContainer = new AttributeContainer(CreeperEntity.createCreeperAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.29D).build());
-        return attributeContainer;
+    
+    public static DefaultAttributeContainer.Builder createSkeletonCreeperAttributes() {
+    	return CreeperEntity.createCreeperAttributes().add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.29D);
     }
-
-
+    
     public boolean canStart() {
         this.closestPlayer = this.world.getClosestPlayer(SkeletonCreeper.CLOSE_PLAYER_PREDICATE, this);
         return this.closestPlayer != null;

--- a/src/main/java/com/finallion/graveyard/entities/WraithEntity.java
+++ b/src/main/java/com/finallion/graveyard/entities/WraithEntity.java
@@ -16,6 +16,7 @@ import net.minecraft.entity.ai.pathing.BirdNavigation;
 import net.minecraft.entity.ai.pathing.EntityNavigation;
 import net.minecraft.entity.ai.pathing.PathNodeType;
 import net.minecraft.entity.attribute.AttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -65,7 +66,6 @@ import java.util.EnumSet;
 import java.util.UUID;
 
 public class WraithEntity extends HostileGraveyardEntity implements IAnimatable {
-    private AttributeContainer attributeContainer;
     private AnimationFactory factory = new AnimationFactory(this);
     private static final UUID ATTACKING_SPEED_BOOST_ID = UUID.fromString("020E0DFB-87AE-4653-9556-831010E291A0");
     private static final EntityAttributeModifier ATTACKING_SPEED_BOOST = new EntityAttributeModifier(ATTACKING_SPEED_BOOST_ID, "Attacking speed boost", 0.2D, EntityAttributeModifier.Operation.ADDITION);
@@ -324,19 +324,13 @@ public class WraithEntity extends HostileGraveyardEntity implements IAnimatable 
         }
         return PlayState.CONTINUE;
     }
-
-    @Override
-    public AttributeContainer getAttributes() {
-        if (attributeContainer == null) {
-            attributeContainer = new AttributeContainer(HostileEntity.createHostileAttributes()
-                    .add(EntityAttributes.GENERIC_MAX_HEALTH, 20.0D)
-                    .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 6.5D)
-                    .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.2)
-                    .add(EntityAttributes.GENERIC_FLYING_SPEED, 0.35).build());
-        }
-        return attributeContainer;
+    
+    public static DefaultAttributeContainer.Builder createWraithAttributes() {
+    	return HostileEntity.createHostileAttributes()
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 6.5D)
+                .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.2)
+                .add(EntityAttributes.GENERIC_FLYING_SPEED, 0.35);
     }
-
 
     public byte getAnimation() {
         return dataTracker.get(ANIMATION);


### PR DESCRIPTION

#### Changes

-Removed custom `AttributeContainer` field from relevant entity classes.
-Removed overridden `LivingEntity#getAttributes` method from relevant entity classes.
+Added static `DefaultAttributeContainer$Builder` method for relevant entity classes. Also removed redundant addition of `EntityAttributes#GENERIC_MAX_HEALTH` where the value was `20.0`, as `LivingEntity` sets this anyway.
+Registered the `DefaultAttributeContainer$Builder` methods to the relevant entity types with the `DefaultAttributeRegistry` using `FabricDefaultAttributeRegistry#register`.


#### Rationale

When setting a custom entity's attributes, the `DefaultAttributeContainer$Builder` object should be registered with the entity type to the `DefaultAttributeRegistry` via Fabric API, and as such handled like vanilla.

Since `LivingEntity` already handles access to the `AttributeContainer`, the `getAttributes()` method should not be overridden, as properly registering a `DefaultAttributeContainer` to the entity type as described above is sufficient.

Regardless of the incompatibility with Data Attributes, it is not optimal to assign an `AttributeContainer` to an entity on the first time it is needed via a  null check - it is better to do this when the entity is initialised/created.

#### Further Notes

The incompatibility with Data Attributes is resolved with this merge. This is applicable for 1.18.2 as that is the version the issue (#40 ) was presented with; however, these changes should also be made to any 1.19+ versions as they are also incompatible with Data Attributes.

I hope that this is acceptable,
Thanks.