### PR TITLE
Fixed access widener

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "graveyard",
-  "version": "3.0",
+  "version": "3.2",
 
   "name": "The Graveyard",
   "description": "Adds new bosses, structures, mobs and blocks themed around the graveyard.",
@@ -16,6 +16,7 @@
   "license": "CC0-1.0",
   "icon": "graveyard_logo.png",
 
+  "accessWidener": "graveyard.accesswidener",
   "environment": "*",
   "entrypoints": {
     "main": [

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ mod_id=graveyard
 mapping_version=1.20.2:2023.12.10
 
 archives_base_name=graveyard
-mod_version=3.2^
+mod_version=3.2
 maven_group=lion.graveyard
 
 fabric_loader_version=0.15.3


### PR DESCRIPTION
Fixed issue when launching mod for fabric.
The problem was caused by a missing line inside the "fabric.mod.json" file

github issue: #75 